### PR TITLE
Add initial unit tests and helper

### DIFF
--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const vm = require('vm');
+
+function include(path) {
+  const code = fs.readFileSync(path, 'utf-8');
+  vm.runInThisContext(code, path);
+}
+
+module.exports = { include };

--- a/tests/unit/tests/utilities.test.js
+++ b/tests/unit/tests/utilities.test.js
@@ -3,7 +3,7 @@
 const assert = require('chai').assert;
 const include = require('../helpers').include;
 
-include('../../scripts/utils/utilities.js');
+include('scripts/utils/utilities.js');
 
 /* global getAllMatches */
 describe('getAllMatches', () => {

--- a/tests/unit/tests/utilities.test.js
+++ b/tests/unit/tests/utilities.test.js
@@ -1,0 +1,32 @@
+/* global require, describe, it */
+
+const assert = require('chai').assert;
+const include = require('../helpers').include;
+
+include('../../scripts/utils/utilities.js');
+
+/* global getAllMatches */
+describe('getAllMatches', () => {
+  it('should return an empty array if no matches found', () => {
+    const html = '<p>Some test text in a paragraph</p>';
+    const pattern = /<(h[2-6]).+>(.+)<\/\1>/ig;
+
+    const result = getAllMatches(pattern, html);
+
+    assert.equal(result.length, 0);
+  });
+
+  it('should return all matches', () => {
+    const html = `
+      <div>
+        <h2 id="firstheading">First heading</h2>
+        <p>Some test text in a paragraph</p>
+        <h3 id="secondheading">Second heading</h3>
+      </div>`;
+    const pattern = /<(h[2-6]).+>(.+)<\/\1>/ig;
+
+    const result = getAllMatches(pattern, html);
+
+    assert.equal(result.length, 2);
+  });
+});


### PR DESCRIPTION
Initial unit test commit to establish a testing setup. The helper method `include()` is necessary to load a normal script file (i.e. one that doesn't use a module format).

You'll need to do two things to get the tests up and running:
1. Install mocha and chai via npm
2. Edit your eslint configuration to add the following rule:
  ```
  "import/no-extraneous-dependencies": [
    "error",
    { "devDependencies": ["**/*.test.js", "**/*.spec.js"]}
  ]
  ```